### PR TITLE
Remove mutinywallet.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Users connect wallets instantly – no Nostr account required. Apps orchestrate 
 - [LNbits](https://lnbits.com/) - Powerful suite of bitcoin tools that has Nostr Wallet Connect plugin
 - [LN Node](https://doc.nostrassets.com/micronode-early-access) - Innovative service designed to simplify the setup and management of a lightning node
 - [Minibits](https://www.minibits.cash/) - eCash wallet with a focus on performance and usability
-- [Mutiny](https://www.mutinywallet.com) - Self-custodial lightning wallet that is targeting the web browser first
 - [nwc-enclaved](https://github.com/nostrband/nwc-enclaved/) - Custodial NWC wallet for a Trusted Execution Environment
 - [Orange Pill App](https://web.orangepillapp.com/login) - Social app with a custodial wallet
 - [Primal Wallet](https://primal.net/) - Custodial wallet integrated with Primal Nostr clients
@@ -241,7 +240,7 @@ These tools and libraries help apps to integrate the NWC protocol and enable in-
 Protocols built on top, or interoperable with NWC
 - [LN Link](https://docs.lnfi.network/lnfi-products/ln-node/ln-link) - Extenstion of NWC for Taproot assets
 - [UMA Auth](https://docs.uma.me/uma-auth/introduction) - Extends NWC to simplify the UX of connecting a wallet (using OAuth 2.0), and add cross-currency payments
-- [Nostr Wallet Auth](https://github.com/nostr-protocol/nips/pull/851?ref=blog.mutinywallet.com) - Protocol allowing to initiate NWC connections from the app instead of from NWC wallets
+- [Nostr Wallet Auth](https://github.com/nostr-protocol/nips/pull/851) - Protocol allowing to initiate NWC connections from the app instead of from NWC wallets
 
 
 ## Contributing


### PR DESCRIPTION
They shut down in December 2024, see: https://blog.mutinywallet.com/mutiny-wallet-is-shutting-down/