### PR TITLE
Add Start With Bitcoin to Education section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following apps are NWC wallet services with access to the APIs of the wallet
 #### Education
 - [Kanbanstr](https://www.kanbanstr.com/) - Kanban boards over Nostr, with zaps
 - [PlebDevs](https://plebdevs.com/) - Online courses on bitcoin & lightning code development
+- [Start With Bitcoin](https://startwithbitcoin.com/) - Guides and tools for AI agents to use Bitcoin via Lightning Network and NWC
 
 #### Exchanges
  - [Bitcoin Well](https://bitcoinwell.com/) - Bitcoin exchange that sends purchased bitcoin directly to your wallet


### PR DESCRIPTION
Adds [Start With Bitcoin](https://startwithbitcoin.com/) to the Education section.

**What it is:** An open-source website and Claude Code skill that teaches AI agents how to use Bitcoin via Lightning Network and NWC.

**Why it fits Education:**
- Step-by-step guides for setting up Nostr identity, NWC wallets, and Lightning payments
- Code examples for AI/agent developers
- Links to MCP servers (Alby MCP, Lightning Enable MCP) and other NWC tools

**Links:**
- Website: https://startwithbitcoin.com
- GitHub (website): https://github.com/bramkanstein/startwithbitcoin
- GitHub (skill): https://github.com/bramkanstein/startwithbitcoin-skill