### PR TITLE
Add OpenReceive and Rizful NWC Tester to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ These tools and libraries help apps to integrate the NWC protocol and enable in-
 - [NWC Tester (Simple)](https://getalby.github.io/nwc-tester/) - Test NWC Connection Secrets
 - [NWC Tester (Advanced)](https://supertestnet.github.io/nwc_tester/) - Check NWC Connection Secrets' permissions, perform events
 - [NWC Tester (With Notification Support)](https://rizful.com/nwc_tester) - Test notifications for a NWC URI
-- [OpenReceive](https://openreceive.org/) - Self-hosted libraries for Node and Rails to accept payments directly into your own wallet via a receive-only NWC connection
+- [OpenReceive](https://openreceive.org/) - Libraries for Node and Rails to accept payments directly into your own wallet via a receive-only NWC connection
 - [pkgzap](https://pkgzap.albylabs.com/) - Support npm packages used by your project and get tipped for your package
 - [Portal SDK](https://github.com/PortalTechnologiesInc/lib) - Nostr-based authentication and payment SDK allowing applications to authenticate users and process payments through Nostr and Lightning Network
 - [Python3 library](https://github.com/supertestnet/python_nwc)

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ These tools and libraries help apps to integrate the NWC protocol and enable in-
 - [nwcjs](https://github.com/supertestnet/nwcjs) - Vanilla Javascript library
 - [NWC Tester (Simple)](https://getalby.github.io/nwc-tester/) - Test NWC Connection Secrets
 - [NWC Tester (Advanced)](https://supertestnet.github.io/nwc_tester/) - Check NWC Connection Secrets' permissions, perform events
+- [NWC Tester (With Notification Support)](https://rizful.com/nwc_tester) - Test notifications for a NWC URI
+- [OpenReceive](https://openreceive.org/) - Self-hosted libraries for Node and Rails to accept payments directly into your own wallet via a receive-only NWC connection
 - [pkgzap](https://pkgzap.albylabs.com/) - Support npm packages used by your project and get tipped for your package
 - [Portal SDK](https://github.com/PortalTechnologiesInc/lib) - Nostr-based authentication and payment SDK allowing applications to authenticate users and process payments through Nostr and Lightning Network
 - [Python3 library](https://github.com/supertestnet/python_nwc)


### PR DESCRIPTION
**OpenReceive** — MIT-licensed, self-hosted libraries (Node and Rails) that let
an app accept inbound lightning payments directly into a wallet the app owner
controls. Connects through a receive-only NWC connection string, so it never
custodies funds and requires no account or API key.
Site: https://openreceive.org/ · Source: https://github.com/OpenReceive/openreceive

**NWC Tester (With Notification Support)** — tests NIP-47 notifications for a
given NWC URI. Grouped with the two existing NWC Tester entries.
https://rizful.com/nwc_tester

Disclosure: I maintain OpenReceive. The Rizful tester is not mine — happy to
split it into a separate PR if you'd prefer one entry per PR.