### PR TITLE
Add Bitcoin Education Archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following apps are NWC wallet services with access to the APIs of the wallet
 
 #### Education
 - [Alby Sandbox](https://sandbox.albylabs.com/) - Explore lightning payment scenarios
+- [Bitcoin Education Archive](https://bitcoineducation.quest/) - Learn Bitcoin through quests, quizzes, and games, earn sats, and tip other learners using NWC
 - [Kanbanstr](https://www.kanbanstr.com/) - Kanban boards over Nostr, with zaps
 - [PlebDevs](https://plebdevs.com/) - Online courses on bitcoin & lightning code development
 - [Start with Bitcoin](https://www.startwithbitcoin.com/) - Give your AI agents identity, wallet, and autonomous payment capabilities using Lightning Network and Nostr


### PR DESCRIPTION
Add Bitcoin Education Archive under Education. The web app offers learning quests, quizzes, games, sat rewards, and tipping with a connected wallet.

Verified NWC support in the deployed wallet module: it accepts NWC connection strings and implements NIP-47 requests including get_balance and pay_invoice.

Sources: https://bitcoineducation.quest/ and https://bitcoineducation.quest/lightning.js?v=20260807_1915

Validation: checked for duplicate listings, alphabetical placement, and git diff --check. No wallet was connected and no payments were made.
